### PR TITLE
Added filtering logic for hospitals and states

### DIFF
--- a/apps/frontend/src/components/ViewFormsList/ViewFormsList.tsx
+++ b/apps/frontend/src/components/ViewFormsList/ViewFormsList.tsx
@@ -18,12 +18,13 @@ import {
 } from '@chakra-ui/react';
 import { getAllForms } from '../../utils/sendRequest';
 import { FormData } from '../../types/formData';
-import { SortOptions } from '../../enums/SortOrder';
+import { SortOptions, SortOrder } from '../../enums/SortOrder';
 
 export default function ViewFormsList() {
   const [forms, setForms] = useState<FormData[]>([]);
   const [allForms, setAllForms] = useState<FormData[]>([]); // this is used to get all forms again after removing a filter/search term
   const [sortBy, setSortBy] = useState<SortOptions>(SortOptions.NAME);
+  const [sortOrder, setSortOrder] = useState<SortOrder>(SortOrder.ASC);
   const [searchTerm, setSearchTerm] = useState<string>('');
 
   // the forms list will be filtered such that only forms whose hospital
@@ -60,7 +61,10 @@ export default function ViewFormsList() {
             : new Date(a.guardianForm.date).getTime())
       );
     }
-  }, [sortBy, forms]);
+    if (sortOrder === SortOrder.DESC) {
+      forms.reverse();
+    }
+  }, [sortBy, sortOrder, forms]);
 
   // filter forms by search term and list of filtering options
   useEffect(() => {
@@ -122,6 +126,15 @@ export default function ViewFormsList() {
         >
           <option value={SortOptions.NAME}>Sort by Name</option>
           <option value={SortOptions.LASTUPDATED}>Sort by Last Updated</option>
+        </Select>
+        <Select 
+        width="25%" 
+        mb={2} 
+        mr={4}
+        onChange={(event) => setSortOrder(event.target.value as SortOrder)}
+        >
+          <option value={SortOrder.ASC}>Ascending</option>
+          <option value={SortOrder.DESC}>Descending</option>
         </Select>
         <Input
           width="25%"

--- a/apps/frontend/src/components/ViewFormsList/ViewFormsList.tsx
+++ b/apps/frontend/src/components/ViewFormsList/ViewFormsList.tsx
@@ -73,8 +73,12 @@ export default function ViewFormsList() {
      the statesToFilter array will be shown; if an array is empty, then that type
      of filtering will not be performed
   */
-  const {setHospitalsToFilter, setStatesToFilter} = useFormsListFiltering(allForms, setForms, searchTerm);
-  
+  const { setHospitalsToFilter, setStatesToFilter } = useFormsListFiltering(
+    allForms,
+    setForms,
+    searchTerm
+  );
+
   useEffect(() => {
     getForms();
   }, []);
@@ -94,11 +98,11 @@ export default function ViewFormsList() {
           <option value={SortOptions.NAME}>Sort by Name</option>
           <option value={SortOptions.LASTUPDATED}>Sort by Last Updated</option>
         </Select>
-        <Select 
-        width="25%" 
-        mb={2} 
-        mr={4}
-        onChange={(event) => setSortOrder(event.target.value as SortOrder)}
+        <Select
+          width="25%"
+          mb={2}
+          mr={4}
+          onChange={(event) => setSortOrder(event.target.value as SortOrder)}
         >
           <option value={SortOrder.ASC}>Ascending</option>
           <option value={SortOrder.DESC}>Descending</option>

--- a/apps/frontend/src/components/ViewFormsList/ViewFormsList.tsx
+++ b/apps/frontend/src/components/ViewFormsList/ViewFormsList.tsx
@@ -19,6 +19,7 @@ import {
 import { getAllForms } from '../../utils/sendRequest';
 import { FormData } from '../../types/formData';
 import { SortOptions, SortOrder } from '../../enums/SortOrder';
+import useFormsListFiltering from '../../hooks/useFormsListFiltering';
 
 export default function ViewFormsList() {
   const [forms, setForms] = useState<FormData[]>([]);
@@ -26,17 +27,6 @@ export default function ViewFormsList() {
   const [sortBy, setSortBy] = useState<SortOptions>(SortOptions.NAME);
   const [sortOrder, setSortOrder] = useState<SortOrder>(SortOrder.ASC);
   const [searchTerm, setSearchTerm] = useState<string>('');
-
-  // the forms list will be filtered such that only forms whose hospital
-  // is in the hospitalsToFilter array and whose state is in the
-  // statesToFilter array will be shown; if an array is empty, then that
-  // type of filtering will not be performed
-
-  // should contain hospital abbreviations exactly as shown in the "hospital" column of the table (e.g., ["MASSGENHOSPITAL"])
-  const [hospitalsToFilter, setHospitalsToFilter] = useState<string[]>([]);
-
-  // should contain states (abbreviations) exactly as shown in the "location" column of the table (e.g., ["MA", "TX"])
-  const [statesToFilter, setStatesToFilter] = useState<string[]>([]);
 
   const getForms = async () => {
     const allForms = await getAllForms();
@@ -66,48 +56,25 @@ export default function ViewFormsList() {
     }
   }, [sortBy, sortOrder, forms]);
 
-  // filter forms by search term and list of filtering options
-  useEffect(() => {
-    let formsToDisplay = allForms;
+  /* Filter forms by search term and lists of hospital and state filtering options;
+     the setters returned by the filtering hook allow the hospitals and states to
+     filter for to be updated
 
-    // filter by search term
-    if (searchTerm.length > 0) {
-      formsToDisplay =
-        formsToDisplay.filter((form) => {
-          const formValues = Object.values({
-            ...form.guardianForm,
-            ...form.medicalForm,
-            ...form.guardianForm.address,
-          });
-          console.log(formValues);
+     Note: hospitalsToFilter should contain only hospital abbreviations as represented
+     in the keys of the HospitalsDropdownValues enum / as they appear in the
+     "hospital" column of the table (e.g., ["BOSHOSPITAL"])
 
-          for (const val of formValues) {
-            if (
-              typeof val === 'string' &&
-              val.toLowerCase().includes(searchTerm.toLowerCase())
-            ) {
-              return true;
-            }
-          }
-          return false;
-        });
-    }
+     Note: statesToFilter should contain only state abbreviations as represented in
+     the keys of the StatesDropdownValues enum / as they appear in the "location"
+     column of the table (e.g., ["MA", "NH"])
 
-    // filter by hospital
-    if (hospitalsToFilter.length > 0) {
-      formsToDisplay =
-        formsToDisplay.filter((form) => hospitalsToFilter.includes(form.medicalForm.hospital))
-    }
-
-    // filter by state ("location")
-    if (statesToFilter.length > 0) {
-      formsToDisplay =
-        formsToDisplay.filter((form) => statesToFilter.includes(form.guardianForm.address.state))
-    }
-
-    setForms(formsToDisplay);
-  }, [searchTerm, hospitalsToFilter, statesToFilter]);
-
+     After filtering by search term, the forms list will be filtered such that only
+     forms whose hospital is in the hospitalsToFilter array and whose state is in
+     the statesToFilter array will be shown; if an array is empty, then that type
+     of filtering will not be performed
+  */
+  const {setHospitalsToFilter, setStatesToFilter} = useFormsListFiltering(allForms, setForms, searchTerm);
+  
   useEffect(() => {
     getForms();
   }, []);

--- a/apps/frontend/src/hooks/useFormsListFiltering.tsx
+++ b/apps/frontend/src/hooks/useFormsListFiltering.tsx
@@ -1,48 +1,56 @@
 import { useState, useEffect } from 'react';
-import { HospitalsDropdownValues, StatesDropdownValues } from '../enums/DropdownValues';
+import {
+  HospitalsDropdownValues,
+  StatesDropdownValues,
+} from '../enums/DropdownValues';
 import { FormData } from '../types/formData';
 
 // Custom hook to filter the given list of forms, set using the
 // given state setter function, using the given search term
 // and the hospitalsToFilter and statesToFilter state variables
 // whose setters are returned by the hook
-export default function useFormsListFiltering(forms: FormData[], setForms: (data: FormData[]) => void,
-                                              searchTerm: string) {
-  
+export default function useFormsListFiltering(
+  forms: FormData[],
+  setForms: (data: FormData[]) => void,
+  searchTerm: string
+) {
   // should contain hospital abbreviations as represented in the keys
   // of the HospitalsDropdownValues enum / as they appear in the
   // "hospital" column of the table (e.g., ["BOSHOSPITAL"])
-  const [hospitalsToFilter, setHospitalsToFilter] = useState<(keyof typeof HospitalsDropdownValues)[]>([]);
+  const [hospitalsToFilter, setHospitalsToFilter] = useState<
+    (keyof typeof HospitalsDropdownValues)[]
+  >([]);
 
   // should contain state abbreviations as represented in the keys of
   // the StatesDropdownValues enum / as they appear in the "location"
   // column of the table (e.g., ["MA", "NH"])
-  const [statesToFilter, setStatesToFilter] = useState<(keyof typeof StatesDropdownValues)[]>([]);
+  const [statesToFilter, setStatesToFilter] = useState<
+    (keyof typeof StatesDropdownValues)[]
+  >([]);
 
   useEffect(() => {
     let formsToDisplay = forms;
-    
+
     // filter by search term
     if (searchTerm.length > 0) {
-      formsToDisplay =
-        formsToDisplay.filter((form) => {
-          const formValues = Object.values({
-            ...form.guardianForm,
-            ...form.medicalForm,
-            ...form.guardianForm.address,
-          });
-          console.log(formValues);
-
-          for (const val of formValues) {
-            if (
-              typeof val === 'string' &&
-              val.toLowerCase().includes(searchTerm.toLowerCase())
-            ) {
-              return true;
-            }
-          }
-          return false;
+      formsToDisplay = formsToDisplay.filter((form) => {
+        const formValues = Object.values({
+          ...form.guardianForm,
+          ...form.medicalForm,
+          ...form.guardianForm.address,
         });
+        console.log(formValues);
+
+        for (const val of formValues) {
+          if (
+            typeof val === 'string' &&
+            val.toLowerCase().includes(searchTerm.toLowerCase())
+          ) {
+            return true;
+          }
+        }
+        return false;
+      });
     }
 
     // the forms list will be filtered such that only forms whose hospital
@@ -52,14 +60,16 @@ export default function useFormsListFiltering(forms: FormData[], setForms: (data
 
     // filter by hospital
     if (hospitalsToFilter.length > 0) {
-      formsToDisplay =
-        formsToDisplay.filter((form) => (hospitalsToFilter as string[]).includes(form.medicalForm.hospital))
+      formsToDisplay = formsToDisplay.filter((form) =>
+        (hospitalsToFilter as string[]).includes(form.medicalForm.hospital)
+      );
     }
 
     // filter by state ("location")
     if (statesToFilter.length > 0) {
-      formsToDisplay =
-        formsToDisplay.filter((form) => (statesToFilter as string[]).includes(form.guardianForm.address.state))
+      formsToDisplay = formsToDisplay.filter((form) =>
+        (statesToFilter as string[]).includes(form.guardianForm.address.state)
+      );
     }
 
     setForms(formsToDisplay);
@@ -67,6 +77,6 @@ export default function useFormsListFiltering(forms: FormData[], setForms: (data
 
   return {
     setHospitalsToFilter: setHospitalsToFilter,
-    setStatesToFilter: setStatesToFilter
+    setStatesToFilter: setStatesToFilter,
   };
 }

--- a/apps/frontend/src/hooks/useFormsListFiltering.tsx
+++ b/apps/frontend/src/hooks/useFormsListFiltering.tsx
@@ -1,0 +1,72 @@
+import { useState, useEffect } from 'react';
+import { HospitalsDropdownValues, StatesDropdownValues } from '../enums/DropdownValues';
+import { FormData } from '../types/formData';
+
+// Custom hook to filter the given list of forms, set using the
+// given state setter function, using the given search term
+// and the hospitalsToFilter and statesToFilter state variables
+// whose setters are returned by the hook
+export default function useFormsListFiltering(forms: FormData[], setForms: React.Dispatch<React.SetStateAction<FormData[]>>,
+                                              searchTerm: string) {
+  
+  // should contain hospital abbreviations as represented in the keys
+  // of the HospitalsDropdownValues enum / as they appear in the
+  // "hospital" column of the table (e.g., ["BOSHOSPITAL"])
+  const [hospitalsToFilter, setHospitalsToFilter] = useState<(keyof typeof HospitalsDropdownValues)[]>([]);
+
+  // should contain state abbreviations as represented in the keys of
+  // the StatesDropdownValues enum / as they appear in the "location"
+  // column of the table (e.g., ["MA", "NH"])
+  const [statesToFilter, setStatesToFilter] = useState<(keyof typeof StatesDropdownValues)[]>([]);
+
+  useEffect(() => {
+    let formsToDisplay = forms;
+    
+    // filter by search term
+    if (searchTerm.length > 0) {
+      formsToDisplay =
+        formsToDisplay.filter((form) => {
+          const formValues = Object.values({
+            ...form.guardianForm,
+            ...form.medicalForm,
+            ...form.guardianForm.address,
+          });
+          console.log(formValues);
+
+          for (const val of formValues) {
+            if (
+              typeof val === 'string' &&
+              val.toLowerCase().includes(searchTerm.toLowerCase())
+            ) {
+              return true;
+            }
+          }
+          return false;
+        });
+    }
+
+    // the forms list will be filtered such that only forms whose hospital
+    // is in the hospitalsToFilter array and whose state is in the
+    // statesToFilter array will be shown; if an array is empty, then that
+    // type of filtering will not be performed
+
+    // filter by hospital
+    if (hospitalsToFilter.length > 0) {
+      formsToDisplay =
+        formsToDisplay.filter((form) => (hospitalsToFilter as string[]).includes(form.medicalForm.hospital))
+    }
+
+    // filter by state ("location")
+    if (statesToFilter.length > 0) {
+      formsToDisplay =
+        formsToDisplay.filter((form) => (statesToFilter as string[]).includes(form.guardianForm.address.state))
+    }
+
+    setForms(formsToDisplay);
+  }, [searchTerm, hospitalsToFilter, statesToFilter]);
+
+  return {
+    setHospitalsToFilter: setHospitalsToFilter,
+    setStatesToFilter: setStatesToFilter
+  };
+}

--- a/apps/frontend/src/hooks/useFormsListFiltering.tsx
+++ b/apps/frontend/src/hooks/useFormsListFiltering.tsx
@@ -6,7 +6,7 @@ import { FormData } from '../types/formData';
 // given state setter function, using the given search term
 // and the hospitalsToFilter and statesToFilter state variables
 // whose setters are returned by the hook
-export default function useFormsListFiltering(forms: FormData[], setForms: React.Dispatch<React.SetStateAction<FormData[]>>,
+export default function useFormsListFiltering(forms: FormData[], setForms: (data: FormData[]) => void,
                                               searchTerm: string) {
   
   // should contain hospital abbreviations as represented in the keys


### PR DESCRIPTION
### ℹ️ Issue

Closes https://trello.com/c/JqeHXPe1

### 📝 Description

Briefly list the changes made to the code:

- Added two new state variables holding arrays of hospitals and states to filter for
    - Hospitals and states should exactly match those shown in the /all-forms table
    - For now, these arrays are initialized to [] and new values are never set; when the filtering UI component is added, it should update these arrays according to which filtering options are checked
- Added filtering logic using these state variables
    - If the hospitalsToFilter array is empty, no hospital filtering is performed; otherwise, only forms with a hospital included in the array of filtering options are shown in the table
    - Similar for states
- Also, the preexisting filter by search term logic would only reset the filter criteria once the entire search box was cleared; this was updated so that the search filtering will be fully reevaluated when the search term is edited in any way
    - e.g., previously, if you added an extra letter to the search term by accident such that no entries would be shown in the table, the entire search term would need to be cleared to reset the filtering; now, simply deleting the last letter would bring the table back to how it looked before the extra letter was added

### ✔️ Verification

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. 

(Note: to see the filtering reflected in the table, you need to interact with something on the page, such as by typing a letter in the search field and then deleting it - see below)
- Changing the initial values of the hospitalsToFilter and statesToFilter state variables to different sets of filter options (such as the examples given in comments), and seeing that the /all-forms page accordingly only shows the correct table entries
- Testing no filtering, filtering only by hospital, filtering only by state, and filtering by both hospital and state at once
- Testing searching the table while state/hospital filtering is also being performed

![image](https://github.com/Code-4-Community/constellation/assets/42777208/35eb3c46-f3d0-4fed-bc08-c45b2cb3de6b)
(filtering by MASSGENHOSPITAL only)

### 🏕️ (Optional) Future Work / Notes

- Preexisting bug: Sort order (ascending/descending) seems to work the opposite of what is intended
- Bug with preexisting sorting and with new filtering options: sorting/filtering does not activate until you interact with something on the /all-forms page (such as by changing one of the dropdown values, typing something in the search box, etc.)