### PR TITLE
Enable/disable form submit button based on required fields / valid form entries

### DIFF
--- a/apps/frontend/src/pages/FormPage.tsx
+++ b/apps/frontend/src/pages/FormPage.tsx
@@ -1,4 +1,4 @@
-import { Button, Center, Spacer } from '@chakra-ui/react';
+import { Button, Center, Spacer, Tooltip } from '@chakra-ui/react';
 import { Form, Formik, FormikHelpers } from 'formik';
 import { FormValues } from '../components/form/Form';
 import { formSchema } from '../types/formSchema';
@@ -18,6 +18,11 @@ const FormPage: React.FC = () => {
     }
   };
 
+  const enableButton = (values: FormValues): boolean => {
+    console.log(values);
+    return true;
+  };
+
   return (
     <Formik
       onSubmit={onSubmit}
@@ -33,9 +38,19 @@ const FormPage: React.FC = () => {
           <MedicalFormPage />
 
           <Center>
-            <Button mt={4} colorScheme="teal" onClick={form.submitForm}>
-              Submit
-            </Button>
+            <Tooltip
+              label="Fill out all required fields first!"
+              isDisabled={enableButton(form.values)}
+            >
+              <Button
+                mt={4}
+                colorScheme="teal"
+                onClick={form.submitForm}
+                isDisabled={!enableButton(form.values)}
+              >
+                Submit
+              </Button>
+            </Tooltip>
           </Center>
         </Form>
       )}

--- a/apps/frontend/src/pages/FormPage.tsx
+++ b/apps/frontend/src/pages/FormPage.tsx
@@ -18,9 +18,19 @@ const FormPage: React.FC = () => {
     }
   };
 
+  /**
+   * Determines whether the submit button should be enabled.
+   *
+   * @param values the values currently entered into the form
+   * @returns true iff the values can be parsed successfully
+   */
   const enableButton = (values: FormValues): boolean => {
-    console.log(values);
-    return true;
+    try {
+      formSchema.validateSync(values);
+      return true;
+    } catch (e) {
+      return false;
+    }
   };
 
   return (


### PR DESCRIPTION
### ℹ️ Issue

Closes https://trello.com/c/KmoKhjBL

### 📝 Description

Briefly list the changes made to the code:

- Changed the submit button to only be enabled when the values entered into the form are such that the form schema could successfully parse the form - i.e., all required fields are filled out, and all fields contain valid values
- Added a tooltip that appears when the user hovers over the disabled submit button that reminds them to fill out all required fields

### ✔️ Verification

I tested the changes by verifying that the submit button is initially disabled, meaning that it appears grayed out, shows a tooltip reminding the user to finish filling out the form, and cannot be clicked. Then, I entered valid values into all the required fields, which enables the submit button, meaning that it appears normal, does not show the tooltip, and can be clicked, which successfully submits the form. I also tested that entering an invalid value into one of the fields, such as a non-email value into an email field, disables the submit button.

![image](https://github.com/Code-4-Community/constellation/assets/42777208/04b379ad-4498-4195-8868-b95e10056aef)
disabled button (mouse cursor hovering over the button not shown)

![image](https://github.com/Code-4-Community/constellation/assets/42777208/b9829b2f-ddfe-489a-ad7d-9683ccfdf50f)
enabled button

### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!

- Due to the way the schema is written, the behavior of when the form requirements are satisfied is not exactly what you would expect just from seeing the red "required" asterisks on the form. For example, if you never type anything into the "Gender" field, the schema is satisfied, but if you type something and then delete it, it is not satisfied.
- If you type in the "Requested Grant Amount" field, click somewhere else, and then try to click back into that field, the form page crashes with an error.
