### PR TITLE
changed the template.yaml to use user group from params

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -86,7 +86,7 @@ image_repositories = []
 resolve_s3 = true
 confirm_changeset = true
 disable_rollback = true
-parameter_overrides = "EnvName='dev', QldbLedgerName='constellation-dev', QldbDeletionProtection='false', QLDBSendCommandRoleName='QLDBSendCommandRole-dev'"
+parameter_overrides = "EnvName='dev', QldbLedgerName='constellation-dev', QldbDeletionProtection='false', QLDBSendCommandRoleName='QLDBSendCommandRole-dev', UserPoolArn='arn:aws:cognito-idp:us-east-1:489881683177:userpool/us-east-1_ItaXWUupj'"
 ```
 
 Then run:

--- a/apps/backend/template.yaml
+++ b/apps/backend/template.yaml
@@ -42,6 +42,10 @@ Parameters:
     Type: String
     Description: 'Name of QLDB Send Command Role'
 
+  UserPoolArn:
+    Type: String
+    Description: 'Resource name of Cognito user group for authorization'
+
 Resources:
   # Defines an IAM role for Lambdas that allows them to:
   # 1. interact with the QLDB transactional data API
@@ -80,7 +84,7 @@ Resources:
       Auth:
         Authorizers:
           CognitoAuthorizer:
-            UserPoolArn: arn:aws:cognito-idp:us-east-1:489881683177:userpool/us-east-1_ItaXWUupj
+            UserPoolArn: !Ref UserPoolArn
 
   # Each Lambda function is defined by properties:
   # https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction


### PR DESCRIPTION
### ℹ️ Issue

Closes #<issue number>

### 📝 Description

The issue this solves is that on the production page, users were not able to access the restricted api endpoints. This is because the cognito authorizer was pointing to the wrong user group. I changed the user group in the aws console, so the problem is fixed, and also updated the template.yaml so future deployments will need to specify the user group arn in the parameters. 

Briefly list the changes made to the code:

- Added support for this.
- And removed redunant use of that.
- Also this was included for reasons.

### ✔️ Verification

What steps did you take to verify your changes work? These should be clear enough for someone to be able to clone the branch and follow the steps themselves. 

Provide screenshots of any new components, styling changes, or pages. 

### 🏕️ (Optional) Future Work / Notes

Did you notice anything ugly during the course of this ticket? Any bugs, design challenges, or unexpected behavior? Write it down so we can clean it up in a future ticket!
