### PR TITLE
popup note when state is other

### DIFF
--- a/apps/frontend/src/components/form/FinancialAssistanceForm.tsx
+++ b/apps/frontend/src/components/form/FinancialAssistanceForm.tsx
@@ -113,6 +113,21 @@ export const HospitalInfoSection: React.FC = () => {
         onChange={(value: string) => handleStateSelectChange(value)}
       />
 
+      {isOtherStatesSelected && (
+        <p>
+          We apologize we must currently give preference to families located
+          near us (within the New England area). Below you can find resources
+          for families for families from other organizations that may be able to
+          better assist you at this time: <br />
+          <a
+            href="https://cac2.org/impact-areas/family-support/hope-portal"
+            style={{ color: 'blue' }}
+          >
+            VISIT THE HOPE PORTAL NOW
+          </a>
+        </p>
+      )}
+
       <FormField
         inputVariant="text"
         name="financialAssistanceForm.hospitalAddress.zipcode"

--- a/apps/frontend/src/components/form/FinancialAssistanceForm.tsx
+++ b/apps/frontend/src/components/form/FinancialAssistanceForm.tsx
@@ -117,7 +117,7 @@ export const HospitalInfoSection: React.FC = () => {
         <p>
           We apologize we must currently give preference to families located
           near us (within the New England area). Below you can find resources
-          for families for families from other organizations that may be able to
+          for families from other organizations that may be able to
           better assist you at this time: <br />
           <a
             href="https://cac2.org/impact-areas/family-support/hope-portal"


### PR DESCRIPTION
### ℹ️ Issue

Closes #28: https://trello.com/c/dadIX3X8

### 📝 Description

Briefly list the changes made to the code:

- Added popup note redirecting to the Hope Portal when grant applicant lives outside the New England area

### ✔️ Verification

No states selected:
<img width="652" alt="Screenshot 2024-02-19 at 7 21 23 PM" src="https://github.com/Code-4-Community/constellation/assets/91427854/4acc5bc6-d18d-405e-afa4-b44e0341af7c">

State in New England selected:
<img width="573" alt="Screenshot 2024-02-19 at 7 21 33 PM" src="https://github.com/Code-4-Community/constellation/assets/91427854/607e35a3-5216-4e95-845c-f0a45a0a2ef0">

State outside New England selected:
<img width="1049" alt="image" src="https://github.com/Code-4-Community/constellation/assets/91427854/69fe730b-b162-4327-88be-f866864c7632">


### 🏕️ (Optional) Future Work / Notes
- Question: I used inline css to get the link to turn blue. should I make a css file instead
- Is it ok for the text to appear underneath that field or should I make it so it is a modal or something
